### PR TITLE
Make header detection case insensitive

### DIFF
--- a/lib/reevoo_mark.php
+++ b/lib/reevoo_mark.php
@@ -29,6 +29,7 @@
 
     function header($name){
       $headers = $this->headers();
+      $name = strtolower($name);
       if(array_key_exists($name, $headers))
         return $headers[$name];
       else
@@ -45,7 +46,7 @@
         $parsed_headers = Array();
         foreach($headers as $header){
           list($key, $value) = split(":", $header, 2);
-          $parsed_headers[$key] = trim($value);
+          $parsed_headers[strtolower($key)] = trim($value);
         }
         $this->headers = $parsed_headers;
         return $this->headers;


### PR DESCRIPTION
Fix for issue #2
maxAge() is checking for the existence of the header "Cache-Control" but the header in the document is lower case so the method does not work as expected.
